### PR TITLE
add Jenkinsfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ compile:
 dev:
 	clojure -A:dev
 
-deploy-website: compile
-	./node_modules/gh-pages/bin/gh-pages.js --dotfiles --message "Deploying latest version" --dist resources/public
+deploy-website:
+	./_assets/bin/gh-pages.js
+
+clean:
+	git clean -d -x -f

--- a/_assets/bin/gh-pages.js
+++ b/_assets/bin/gh-pages.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+var ghpages = require('gh-pages')
+
+if (!process.env.GH_REPO) { throw "Env variable GH_REPO needs to be set!" }
+if (!process.env.GH_USER) { throw "Env variable GH_USER needs to be set!" }
+if (!process.env.GH_PASS) { throw "Env variable GH_PASS needs to be set!" }
+ 
+console.log('Deploying...')
+
+ghpages.publish('resources/public', {
+  repo: ( 
+    'https://'
+    + process.env.GH_USER + ':'
+    + process.env.GH_PASS
+    + `@github.com/${process.env.GH_REPO}.git`
+  ),
+  message: 'Deploying latest version',
+  branch: 'gh-pages',
+  dotfiles: true,
+  silent: false,
+}, function(err) {
+  if (err !== undefined) {
+    console.error(err)
+    process.exit(1)
+  } else {
+    console.log(`Successfully deployed to ${process.env.GH_REPO}!`)
+  }
+})

--- a/_assets/ci/Jenkinsfile
+++ b/_assets/ci/Jenkinsfile
@@ -1,0 +1,57 @@
+pipeline {
+  
+  /* This image comes from _assets/docker */
+  agent {
+    docker {
+      label 'linux'
+      image 'statusteam/clojure:latest'
+    }
+  }
+
+  options {
+    timestamps()
+    /* avoid race conditions on deploy */
+    disableConcurrentBuilds()
+    /* manage how many builds we keep */
+    buildDiscarder(logRotator(numToKeepStr: '60'))
+  }
+
+  environment {
+    GH_REPO = 'status-im/extensions-fiddle'
+    GH_USER = 'status-im-auto'
+    GH_MAIL = 'auto@status.im'
+    HOME    = '/tmp'
+  }
+
+  stages {
+    stage('Prep') {
+      steps {
+        sh "git config user.name  ${GH_USER}"
+        sh "git config user.email ${GH_MAIL}"
+        sh 'yarn install'
+      }
+    }
+
+    stage('Build') {
+      steps {
+        sh 'make compile'
+      }
+    }
+
+    stage('Publish') {
+      steps { script {
+        test = ''
+        withCredentials([usernamePassword(
+          credentialsId: 'status-im-auto',
+          usernameVariable: 'GH_USER',
+          passwordVariable: 'GH_PASS'
+        )]) {
+          sh 'make deploy-website'
+        }
+      } }
+    }
+  }
+  post {
+    always { sh 'make clean' }
+  }
+}

--- a/_assets/docker/Dockerfile
+++ b/_assets/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM clojure:openjdk-8-tools-deps-1.10.0.414-alpine
+
+RUN apk --no-cache add git make nodejs yarn
+
+MAINTAINER Jakub Sokolowski "jakub@status.im"
+LABEL description="Basic image with Clojure for building in CI."
+
+ENTRYPOINT []

--- a/_assets/docker/Makefile
+++ b/_assets/docker/Makefile
@@ -1,0 +1,8 @@
+IMAGE_TAG = latest
+IMAGE_NAME = statusteam/clojure:$(IMAGE_TAG)
+
+build:
+	docker build -t $(IMAGE_NAME) .
+
+push: build
+	docker push $(IMAGE_NAME)


### PR DESCRIPTION
Adding:

* `_assets/ci/Jenkinsfile` - Used by https://ci.status.im/job/misc/job/extensions.status.im/
* `_assets/bin/gh-pages.js` - Wrapper around `gh-pages` module to provide auth via env variables.
* `_assets/docker/Dockerfile` - For building `statusteam/clojure:latest` image used in CI builds.
* `_assets/docker/Makefile` - For convenience.

Once merged we'll have to change default branch in the CI job to `master`.